### PR TITLE
feat: Conv kernel size

### DIFF
--- a/dragonfly/env/gym/carracing/ppo.json
+++ b/dragonfly/env/gym/carracing/ppo.json
@@ -33,7 +33,7 @@
 		            "original_dim": [24,24,4],
                 "trunk": {
                     "filters": [8,16],
-		                "kernel": [12,3],
+		                "kernels": [12,3],
 		                "stride": 1,
                     "pooling": true,
                     "actv": "relu"
@@ -63,7 +63,7 @@
 		            "original_dim": [24,24,4],
                 "trunk": {
                     "filters": [8,16],
-		                "kernel": [12,3],
+		                "kernels": [12,3],
 		                "stride": 1,
                     "pooling": true,
                     "actv": "relu"

--- a/dragonfly/src/network/conv2d.py
+++ b/dragonfly/src/network/conv2d.py
@@ -22,7 +22,7 @@ class conv2d(base_network):
         # Set default values
         self.trunk         = trunk()
         self.trunk.filters = [64]
-        self.trunk.kernel  = 3
+        self.trunk.kernels = [3]
         self.trunk.stride  = 1
         self.trunk.actv    = "relu"
         self.heads         = heads()
@@ -38,7 +38,7 @@ class conv2d(base_network):
         # Check inputs
         if hasattr(pms,       "trunk"):        self.trunk         = pms.trunk
         if hasattr(pms.trunk, "filters"):      self.trunk.filters = pms.trunk.filters
-        if hasattr(pms.trunk, "kernel"):       self.trunk.kernel  = pms.trunk.kernel
+        if hasattr(pms.trunk, "kernels"):      self.trunk.kernels  = pms.trunk.kernels
         if hasattr(pms.trunk, "strides"):      self.trunk.stride  = pms.trunk.stride
         if hasattr(pms.trunk, "actv"):         self.trunk.actv    = pms.trunk.actv
         if hasattr(pms,       "heads"):        self.heads         = pms.heads
@@ -65,14 +65,14 @@ class conv2d(base_network):
         self.net = []
 
         assert len(self.trunk.filters) == len(
-            self.trunk.kernel
-        ), f"Wrong kernel list. Expected {len(self.trunk.filters)} elements, got {len(self.trunk.kernel)}."
+            self.trunk.kernels
+        ), f"Wrong kernel list. Expected {len(self.trunk.filters)} elements, got {len(self.trunk.kernels)}."
 
         # Define trunk
         for l in range(len(self.trunk.filters)):
             if (l == 0):
                 self.net.append(Conv2D(filters            = self.trunk.filters[l],
-                                       kernel_size        = self.trunk.kernel[l],
+                                       kernel_size        = self.trunk.kernels[l],
                                        strides            = self.trunk.stride,
                                        kernel_initializer = self.k_init,
                                        activation         = self.trunk.actv,
@@ -80,7 +80,7 @@ class conv2d(base_network):
                                        padding            = "same"))
             else:
                 self.net.append(Conv2D(filters            = self.trunk.filters[l],
-                                       kernel_size        = self.trunk.kernel[l],
+                                       kernel_size        = self.trunk.kernels[l],
                                        strides            = self.trunk.stride,
                                        kernel_initializer = self.k_init,
                                        activation         = self.trunk.actv,

--- a/dragonfly/tst/network/conv2d.json
+++ b/dragonfly/tst/network/conv2d.json
@@ -33,7 +33,7 @@
 		            "original_dim": [48,48,4],
                 "trunk": {
                     "filters": [4,4],
-		                "kernel": [3,3],
+		                "kernels": [3,3],
 		                "stride": 1,
                     "actv": "tanh"
                 },
@@ -62,7 +62,7 @@
 		            "original_dim": [48,48,4],
                 "trunk": {
                     "filters": [4,4],
-		                "kernel": [3,3],
+		                "kernels": [3,3],
 		                "stride": 1,
                     "actv": "selu"
                 },


### PR DESCRIPTION
We update the kernel parameter to make it a list instead of an int.
We make sure it's the same size as the filter parameter.

**We change the kernel size to 12 for the carracing to make sure it the NN works even while being not deep at all**

Misc:
- update the car racing env file to make it faster (and make it work)
- update 2 .json file that use Conv2D
- Small typo in the reading of the conv2D parameters file